### PR TITLE
Refactor/cairo parser

### DIFF
--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -65,15 +65,15 @@ export default class CairoParser {
 
         const parsingOutput = {
           attributeName: functionSignatureParser.getAttributeName(
-            functionScope!
+            functionScope
           ),
           functionName: functionSignatureParser.getFunctionName(functionScope!),
           functionSignature: {
             implicitArgs: functionSignatureParser.getImplicitArgs(
-              functionScope!
+              functionScope
             ),
             explicitArgs: functionSignatureParser.getExplicitArgs(
-              functionScope!
+              functionScope
             ),
           },
           functionComment: {

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -19,11 +19,11 @@ export default class CairoParser {
   }
 
   // parse whole scope
-  static parseFunctionScope(filePath: string, name: string): string | null {
+  static parseFunctionScope(filePath: string, name: string): RegExpMatchArray | null {
     const text = fs.readFileSync(filePath, "utf8");
     const result = text.match(this.getRegex(name));
     if (result) {
-      return result[0];
+      return result;
     }
     return null;
   }
@@ -39,15 +39,19 @@ export default class CairoParser {
   static getScopeParsingResult(
     filePath: string,
     name: string
-  ): parsingResult | null {
+  ): parsingResult[] | null {
     const functionScopeLines = CairoParser.parseFunctionScope(filePath, name);
 
     // Function signature parsing
     const functionSignatureParser = new FunctionSignatureRegexParser();
 
+    var parsingOutputs = [];
+
     // parse comment lines
     if (functionScopeLines) {
-      const commentLines = CairoParser.parseCommentLines(functionScopeLines);
+      for (var functionScope of functionScopeLines){
+
+      const commentLines = CairoParser.parseCommentLines(functionScope);
 
       const functionCommentDescParser = new FunctionCommentDescParser();
       const functionCommentImplicitArgsParser =
@@ -57,19 +61,19 @@ export default class CairoParser {
       const functionCommentReturnsParser = new FunctionCommentReturnsParser();
       const functionCommentRaisesParser = new FunctionCommentRaisesParser();
 
-      var parsingOutput = {
+      const parsingOutput = {
         attributeName: functionSignatureParser.getAttributeName(
-          functionScopeLines!
+          functionScope!
         ),
         functionName: functionSignatureParser.getFunctionName(
-          functionScopeLines!
+          functionScope!
         ),
         functionSignature: {
           implicitArgs: functionSignatureParser.getImplicitArgs(
-            functionScopeLines!
+            functionScope!
           ),
           explicitArgs: functionSignatureParser.getExplicitArgs(
-            functionScopeLines!
+            functionScope!
           ),
         },
         functionComment: {
@@ -86,7 +90,12 @@ export default class CairoParser {
           raises: functionCommentRaisesParser.parseCommentLines(commentLines!),
         },
       };
-      return parsingOutput;
+
+      parsingOutputs.push(parsingOutput);
+
+      }
+      
+      return parsingOutputs;
     }
     return null;
   }

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -19,13 +19,13 @@ export default class CairoParser {
   }
 
   // parse whole scope
-  static parseFunctionScope(filePath: string, name: string): string {
+  static parseFunctionScope(filePath: string, name: string): string | null {
     const text = fs.readFileSync(filePath, "utf8");
     const result = text.match(this.getRegex(name));
     if (result) {
       return result[0];
     }
-    return "";
+    return null;
   }
 
   // parse only commented lines
@@ -36,46 +36,59 @@ export default class CairoParser {
   }
 
   // parse whole scope and return appropiate data structure
-  static getScopeParsingResult(filePath: string, name: string): parsingResult {
+  static getScopeParsingResult(
+    filePath: string,
+    name: string
+  ): parsingResult | null {
     const functionScopeLines = CairoParser.parseFunctionScope(filePath, name);
 
     // Function signature parsing
     const functionSignatureParser = new FunctionSignatureRegexParser();
 
     // parse comment lines
-    const commentLines = CairoParser.parseCommentLines(functionScopeLines);
+    if (functionScopeLines) {
+      const commentLines = CairoParser.parseCommentLines(functionScopeLines);
 
-    const functionCommentDescParser = new FunctionCommentDescParser();
-    const functionCommentImplicitArgsParser =
-      new FunctionCommentImplicitArgsParser();
-    const functionCommentExplicitArgsParser =
-      new FunctionCommentExplicitArgsParser();
-    const functionCommentReturnsParser = new FunctionCommentReturnsParser();
-    const functionCommentRaisesParser = new FunctionCommentRaisesParser();
+      const functionCommentDescParser = new FunctionCommentDescParser();
+      const functionCommentImplicitArgsParser =
+        new FunctionCommentImplicitArgsParser();
+      const functionCommentExplicitArgsParser =
+        new FunctionCommentExplicitArgsParser();
+      const functionCommentReturnsParser = new FunctionCommentReturnsParser();
+      const functionCommentRaisesParser = new FunctionCommentRaisesParser();
 
-    var parsingOutput = {
-      attributeName:
-        functionSignatureParser.getAttributeName(functionScopeLines),
-      functionName: functionSignatureParser.getFunctionName(functionScopeLines),
-      functionSignature: {
-        implicitArgs:
-          functionSignatureParser.getImplicitArgs(functionScopeLines),
-        explicitArgs:
-          functionSignatureParser.getExplicitArgs(functionScopeLines),
-      },
-      functionComment: {
-        desc: functionCommentDescParser.parseCommentLines(commentLines!),
-        implicitArgs: functionCommentImplicitArgsParser.parseCommentLines(
-          commentLines!
+      var parsingOutput = {
+        attributeName: functionSignatureParser.getAttributeName(
+          functionScopeLines!
         ),
-        explicitArgs: functionCommentExplicitArgsParser.parseCommentLines(
-          commentLines!
+        functionName: functionSignatureParser.getFunctionName(
+          functionScopeLines!
         ),
-        returns: functionCommentReturnsParser.parseCommentLines(commentLines!),
-        raises: functionCommentRaisesParser.parseCommentLines(commentLines!),
-      },
-    };
-    return parsingOutput;
+        functionSignature: {
+          implicitArgs: functionSignatureParser.getImplicitArgs(
+            functionScopeLines!
+          ),
+          explicitArgs: functionSignatureParser.getExplicitArgs(
+            functionScopeLines!
+          ),
+        },
+        functionComment: {
+          desc: functionCommentDescParser.parseCommentLines(commentLines!),
+          implicitArgs: functionCommentImplicitArgsParser.parseCommentLines(
+            commentLines!
+          ),
+          explicitArgs: functionCommentExplicitArgsParser.parseCommentLines(
+            commentLines!
+          ),
+          returns: functionCommentReturnsParser.parseCommentLines(
+            commentLines!
+          ),
+          raises: functionCommentRaisesParser.parseCommentLines(commentLines!),
+        },
+      };
+      return parsingOutput;
+    }
+    return null;
   }
 
   // TODO: dump all parsed data to a file
@@ -84,8 +97,5 @@ export default class CairoParser {
   // TODO: check if there's mismatch between function signature and comment
   // https://github.com/onlydustxyz/kaaper/issues/7
 
-
   // TODO: parse all files under a directory
-
-  
 }

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -19,7 +19,10 @@ export default class CairoParser {
   }
 
   // parse whole scope
-  static parseFunctionScope(filePath: string, name: string): RegExpMatchArray | null {
+  static parseFunctionScope(
+    filePath: string,
+    name: string
+  ): RegExpMatchArray | null {
     const text = fs.readFileSync(filePath, "utf8");
     const result = text.match(this.getRegex(name));
     if (result) {
@@ -39,7 +42,7 @@ export default class CairoParser {
   static getScopeParsingResult(
     filePath: string,
     name: string
-  ): parsingResult[] | null {
+  ): ParsingResult[] | null {
     const functionScopeLines = CairoParser.parseFunctionScope(filePath, name);
 
     // Function signature parsing
@@ -49,52 +52,50 @@ export default class CairoParser {
 
     // parse comment lines
     if (functionScopeLines) {
-      for (var functionScope of functionScopeLines){
+      for (var functionScope of functionScopeLines) {
+        const commentLines = CairoParser.parseCommentLines(functionScope);
 
-      const commentLines = CairoParser.parseCommentLines(functionScope);
+        const functionCommentDescParser = new FunctionCommentDescParser();
+        const functionCommentImplicitArgsParser =
+          new FunctionCommentImplicitArgsParser();
+        const functionCommentExplicitArgsParser =
+          new FunctionCommentExplicitArgsParser();
+        const functionCommentReturnsParser = new FunctionCommentReturnsParser();
+        const functionCommentRaisesParser = new FunctionCommentRaisesParser();
 
-      const functionCommentDescParser = new FunctionCommentDescParser();
-      const functionCommentImplicitArgsParser =
-        new FunctionCommentImplicitArgsParser();
-      const functionCommentExplicitArgsParser =
-        new FunctionCommentExplicitArgsParser();
-      const functionCommentReturnsParser = new FunctionCommentReturnsParser();
-      const functionCommentRaisesParser = new FunctionCommentRaisesParser();
-
-      const parsingOutput = {
-        attributeName: functionSignatureParser.getAttributeName(
-          functionScope!
-        ),
-        functionName: functionSignatureParser.getFunctionName(
-          functionScope!
-        ),
-        functionSignature: {
-          implicitArgs: functionSignatureParser.getImplicitArgs(
+        const parsingOutput = {
+          attributeName: functionSignatureParser.getAttributeName(
             functionScope!
           ),
-          explicitArgs: functionSignatureParser.getExplicitArgs(
-            functionScope!
-          ),
-        },
-        functionComment: {
-          desc: functionCommentDescParser.parseCommentLines(commentLines!),
-          implicitArgs: functionCommentImplicitArgsParser.parseCommentLines(
-            commentLines!
-          ),
-          explicitArgs: functionCommentExplicitArgsParser.parseCommentLines(
-            commentLines!
-          ),
-          returns: functionCommentReturnsParser.parseCommentLines(
-            commentLines!
-          ),
-          raises: functionCommentRaisesParser.parseCommentLines(commentLines!),
-        },
-      };
+          functionName: functionSignatureParser.getFunctionName(functionScope!),
+          functionSignature: {
+            implicitArgs: functionSignatureParser.getImplicitArgs(
+              functionScope!
+            ),
+            explicitArgs: functionSignatureParser.getExplicitArgs(
+              functionScope!
+            ),
+          },
+          functionComment: {
+            desc: functionCommentDescParser.parseCommentLines(commentLines!),
+            implicitArgs: functionCommentImplicitArgsParser.parseCommentLines(
+              commentLines!
+            ),
+            explicitArgs: functionCommentExplicitArgsParser.parseCommentLines(
+              commentLines!
+            ),
+            returns: functionCommentReturnsParser.parseCommentLines(
+              commentLines!
+            ),
+            raises: functionCommentRaisesParser.parseCommentLines(
+              commentLines!
+            ),
+          },
+        };
 
-      parsingOutputs.push(parsingOutput);
-
+        parsingOutputs.push(parsingOutput);
       }
-      
+
       return parsingOutputs;
     }
     return null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,7 +9,7 @@ interface FunctionComment {
   desc: string;
 }
 
-interface parsingResult {
+interface ParsingResult {
   attributeName: string;
   functionName: string;
   functionSignature: {

--- a/src/test/suite/function-comment/constructor/desc.test.ts
+++ b/src/test/suite/function-comment/constructor/desc.test.ts
@@ -13,7 +13,7 @@ suite("function-comment: constructor: desc", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
 
     const descParser = new FunctionCommentDescParser();
 
@@ -46,7 +46,7 @@ suite("function-comment: constructor: desc", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const descParser = new FunctionCommentDescParser();
     descParser.setStartScope(commentText![0]);
 
@@ -92,7 +92,7 @@ suite("function-comment: constructor: desc", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const descParser = new FunctionCommentDescParser();
     descParser.setStartScope(commentText![0]);
 
@@ -134,7 +134,7 @@ suite("function-comment: constructor: desc", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
 
     const descParser = new FunctionCommentDescParser();
 

--- a/src/test/suite/function-comment/constructor/desc.test.ts
+++ b/src/test/suite/function-comment/constructor/desc.test.ts
@@ -13,7 +13,7 @@ suite("function-comment: constructor: desc", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
 
     const descParser = new FunctionCommentDescParser();
 
@@ -46,7 +46,7 @@ suite("function-comment: constructor: desc", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const descParser = new FunctionCommentDescParser();
     descParser.setStartScope(commentText![0]);
 
@@ -92,7 +92,7 @@ suite("function-comment: constructor: desc", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const descParser = new FunctionCommentDescParser();
     descParser.setStartScope(commentText![0]);
 
@@ -134,7 +134,7 @@ suite("function-comment: constructor: desc", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
 
     const descParser = new FunctionCommentDescParser();
 

--- a/src/test/suite/function-comment/constructor/explicit-args.test.ts
+++ b/src/test/suite/function-comment/constructor/explicit-args.test.ts
@@ -13,7 +13,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
 
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
 
@@ -57,7 +57,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -101,7 +101,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -148,7 +148,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -195,7 +195,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -242,7 +242,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -289,7 +289,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -328,7 +328,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
 
     const targetLineParsing = [

--- a/src/test/suite/function-comment/constructor/explicit-args.test.ts
+++ b/src/test/suite/function-comment/constructor/explicit-args.test.ts
@@ -13,7 +13,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
 
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
 
@@ -57,7 +57,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -101,7 +101,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -148,7 +148,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -195,7 +195,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -242,7 +242,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -289,7 +289,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
     explicitArgsParser.setStartScope(commentText![6]);
 
@@ -328,7 +328,7 @@ suite("function-comment: constructor: explicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const explicitArgsParser = new FunctionCommentExplicitArgsParser();
 
     const targetLineParsing = [

--- a/src/test/suite/function-comment/constructor/implicit-args.test.ts
+++ b/src/test/suite/function-comment/constructor/implicit-args.test.ts
@@ -13,7 +13,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
 
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
 
@@ -54,7 +54,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     implicitArgsParser.setStartScope(commentText![2]);
 
@@ -98,7 +98,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     implicitArgsParser.setStartScope(commentText![2]);
 
@@ -146,7 +146,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     implicitArgsParser.setStartScope(commentText![2]);
 
@@ -195,7 +195,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     implicitArgsParser.setStartScope(commentText![2]);
 
@@ -245,7 +245,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     const targetLineParsing = [
       { name: "syscall_ptr", type: "felt*", desc: "" },

--- a/src/test/suite/function-comment/constructor/implicit-args.test.ts
+++ b/src/test/suite/function-comment/constructor/implicit-args.test.ts
@@ -13,7 +13,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
 
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
 
@@ -54,7 +54,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     implicitArgsParser.setStartScope(commentText![2]);
 
@@ -98,7 +98,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     implicitArgsParser.setStartScope(commentText![2]);
 
@@ -146,7 +146,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     implicitArgsParser.setStartScope(commentText![2]);
 
@@ -195,7 +195,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     implicitArgsParser.setStartScope(commentText![2]);
 
@@ -245,7 +245,7 @@ suite("function-comment: constructor: implicit-args", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const implicitArgsParser = new FunctionCommentImplicitArgsParser();
     const targetLineParsing = [
       { name: "syscall_ptr", type: "felt*", desc: "" },

--- a/src/test/suite/function-comment/constructor/raises.test.ts
+++ b/src/test/suite/function-comment/constructor/raises.test.ts
@@ -14,7 +14,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
 
     const raisesParser = new FunctionCommentRaisesParser();
 
@@ -52,7 +52,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const raisesParser = new FunctionCommentRaisesParser();
     raisesParser.setStartScope(commentText![14]);
 
@@ -94,7 +94,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const raisesParser = new FunctionCommentRaisesParser();
     raisesParser.setStartScope(commentText![14]);
 
@@ -136,7 +136,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const raisesParser = new FunctionCommentRaisesParser();
     raisesParser.setStartScope(commentText![14]);
 
@@ -178,7 +178,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const raisesParser = new FunctionCommentRaisesParser();
     raisesParser.setStartScope(commentText![14]);
 
@@ -220,7 +220,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const raisesParser = new FunctionCommentRaisesParser();
 
     const targetLineParsing = [

--- a/src/test/suite/function-comment/constructor/raises.test.ts
+++ b/src/test/suite/function-comment/constructor/raises.test.ts
@@ -14,7 +14,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
 
     const raisesParser = new FunctionCommentRaisesParser();
 
@@ -52,7 +52,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const raisesParser = new FunctionCommentRaisesParser();
     raisesParser.setStartScope(commentText![14]);
 
@@ -94,7 +94,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const raisesParser = new FunctionCommentRaisesParser();
     raisesParser.setStartScope(commentText![14]);
 
@@ -136,7 +136,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const raisesParser = new FunctionCommentRaisesParser();
     raisesParser.setStartScope(commentText![14]);
 
@@ -178,7 +178,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const raisesParser = new FunctionCommentRaisesParser();
     raisesParser.setStartScope(commentText![14]);
 
@@ -220,7 +220,7 @@ suite("function-comment: constructor: raises", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const raisesParser = new FunctionCommentRaisesParser();
 
     const targetLineParsing = [

--- a/src/test/suite/function-comment/constructor/returns.test.ts
+++ b/src/test/suite/function-comment/constructor/returns.test.ts
@@ -14,7 +14,7 @@ suite("function-comment: constructor: returns", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
 
     const returnsParser = new FunctionCommentReturnsParser();
 
@@ -54,7 +54,7 @@ suite("function-comment: constructor: returns", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const returnsParser = new FunctionCommentReturnsParser();
     returnsParser.setStartScope(commentText![12]);
 
@@ -90,7 +90,7 @@ suite("function-comment: constructor: returns", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const returnsParser = new FunctionCommentReturnsParser();
     returnsParser.setStartScope(commentText![12]);
 
@@ -129,7 +129,7 @@ suite("function-comment: constructor: returns", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText);
+    const commentText = CairoParser.parseCommentLines(functionText!);
     const returnsParser = new FunctionCommentReturnsParser();
 
     const targetLineParsing = [{ name: "", type: "", desc: "None" }];

--- a/src/test/suite/function-comment/constructor/returns.test.ts
+++ b/src/test/suite/function-comment/constructor/returns.test.ts
@@ -14,7 +14,7 @@ suite("function-comment: constructor: returns", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
 
     const returnsParser = new FunctionCommentReturnsParser();
 
@@ -54,7 +54,7 @@ suite("function-comment: constructor: returns", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const returnsParser = new FunctionCommentReturnsParser();
     returnsParser.setStartScope(commentText![12]);
 
@@ -90,7 +90,7 @@ suite("function-comment: constructor: returns", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const returnsParser = new FunctionCommentReturnsParser();
     returnsParser.setStartScope(commentText![12]);
 
@@ -129,7 +129,7 @@ suite("function-comment: constructor: returns", () => {
       pathFile,
       "constructor"
     );
-    const commentText = CairoParser.parseCommentLines(functionText!);
+    const commentText = CairoParser.parseCommentLines(functionText![0]);
     const returnsParser = new FunctionCommentReturnsParser();
 
     const targetLineParsing = [{ name: "", type: "", desc: "None" }];

--- a/src/test/suite/function-signature/constructor.test.ts
+++ b/src/test/suite/function-signature/constructor.test.ts
@@ -16,7 +16,7 @@ suite("function-signature: constructor", () => {
 
     const functionSignatureParser = new FunctionSignatureRegexParser();
     const attributeName = functionSignatureParser.getAttributeName(
-      constructorText!
+      constructorText![0]
     );
     assert.equal("constructor", attributeName, "failed to get attribute name");
   });
@@ -32,7 +32,7 @@ suite("function-signature: constructor", () => {
 
     const functionSignatureParser = new FunctionSignatureRegexParser();
     const functionName = functionSignatureParser.getFunctionName(
-      constructorText!
+      constructorText![0]
     );
     assert.equal("constructor", functionName, "failed to get attribute name");
   });
@@ -49,7 +49,7 @@ suite("function-signature: constructor", () => {
 
     const functionSignatureParser = new FunctionSignatureRegexParser();
     const implicitArgs = functionSignatureParser.getImplicitArgs(
-      constructorText!
+      constructorText![0]
     );
     const targetImplicitArgs = [
       { name: "syscall_ptr", type: "felt*" },
@@ -75,7 +75,7 @@ suite("function-signature: constructor", () => {
 
     const functionSignatureParser = new FunctionSignatureRegexParser();
     const explicitArgs = functionSignatureParser.getExplicitArgs(
-      constructorText!
+      constructorText![0]
     );
     const targetExplicitArgs = [
       { name: "name", type: "felt" },

--- a/src/test/suite/function-signature/constructor.test.ts
+++ b/src/test/suite/function-signature/constructor.test.ts
@@ -15,8 +15,9 @@ suite("function-signature: constructor", () => {
     );
 
     const functionSignatureParser = new FunctionSignatureRegexParser();
-    const attributeName =
-      functionSignatureParser.getAttributeName(constructorText);
+    const attributeName = functionSignatureParser.getAttributeName(
+      constructorText!
+    );
     assert.equal("constructor", attributeName, "failed to get attribute name");
   });
   test("get function name", () => {
@@ -30,8 +31,9 @@ suite("function-signature: constructor", () => {
     );
 
     const functionSignatureParser = new FunctionSignatureRegexParser();
-    const functionName =
-      functionSignatureParser.getFunctionName(constructorText);
+    const functionName = functionSignatureParser.getFunctionName(
+      constructorText!
+    );
     assert.equal("constructor", functionName, "failed to get attribute name");
   });
 
@@ -46,8 +48,9 @@ suite("function-signature: constructor", () => {
     );
 
     const functionSignatureParser = new FunctionSignatureRegexParser();
-    const implicitArgs =
-      functionSignatureParser.getImplicitArgs(constructorText);
+    const implicitArgs = functionSignatureParser.getImplicitArgs(
+      constructorText!
+    );
     const targetImplicitArgs = [
       { name: "syscall_ptr", type: "felt*" },
       { name: "pedersen_ptr", type: "HashBuiltin*" },
@@ -71,8 +74,9 @@ suite("function-signature: constructor", () => {
     );
 
     const functionSignatureParser = new FunctionSignatureRegexParser();
-    const explicitArgs =
-      functionSignatureParser.getExplicitArgs(constructorText);
+    const explicitArgs = functionSignatureParser.getExplicitArgs(
+      constructorText!
+    );
     const targetExplicitArgs = [
       { name: "name", type: "felt" },
       { name: "symbol", type: "felt" },

--- a/src/test/suite/integration/constructor.test.ts
+++ b/src/test/suite/integration/constructor.test.ts
@@ -26,7 +26,7 @@ suite("integration-test:", () => {
 
     // Comment parsing
     // parse comment lines
-    const commentLines = CairoParser.parseCommentLines(functionScopeLines!);
+    const commentLines = CairoParser.parseCommentLines(functionScopeLines![0]);
 
     const functionCommentDescParser = new FunctionCommentDescParser();
     const functionCommentImplicitArgsParser =
@@ -36,7 +36,7 @@ suite("integration-test:", () => {
     const functionCommentReturnsParser = new FunctionCommentReturnsParser();
     const functionCommentRaisesParser = new FunctionCommentRaisesParser();
 
-    const parsingTarget = {
+    const parsingTarget = [{
       attributeName: "constructor",
       functionName: "constructor",
       functionSignature: {
@@ -91,21 +91,21 @@ suite("integration-test:", () => {
           { name: "initial_supply", type: "", desc: "mint overflow" },
         ],
       },
-    };
+    }];
 
-    var parsingOutput = {
+    var parsingOutput = [{
       attributeName: functionSignatureParser.getAttributeName(
-        functionScopeLines!
+        functionScopeLines![0]
       ),
       functionName: functionSignatureParser.getFunctionName(
-        functionScopeLines!
+        functionScopeLines![0]
       ),
       functionSignature: {
         implicitArgs: functionSignatureParser.getImplicitArgs(
-          functionScopeLines!
+          functionScopeLines![0]
         ),
         explicitArgs: functionSignatureParser.getExplicitArgs(
-          functionScopeLines!
+          functionScopeLines![0]
         ),
       },
       functionComment: {
@@ -119,7 +119,7 @@ suite("integration-test:", () => {
         returns: functionCommentReturnsParser.parseCommentLines(commentLines!),
         raises: functionCommentRaisesParser.parseCommentLines(commentLines!),
       },
-    };
+    }];
 
     assert.deepEqual(parsingTarget, parsingOutput, "failed to parse");
   });

--- a/src/test/suite/integration/constructor.test.ts
+++ b/src/test/suite/integration/constructor.test.ts
@@ -26,7 +26,7 @@ suite("integration-test:", () => {
 
     // Comment parsing
     // parse comment lines
-    const commentLines = CairoParser.parseCommentLines(functionScopeLines);
+    const commentLines = CairoParser.parseCommentLines(functionScopeLines!);
 
     const functionCommentDescParser = new FunctionCommentDescParser();
     const functionCommentImplicitArgsParser =
@@ -94,14 +94,19 @@ suite("integration-test:", () => {
     };
 
     var parsingOutput = {
-      attributeName:
-        functionSignatureParser.getAttributeName(functionScopeLines),
-      functionName: functionSignatureParser.getFunctionName(functionScopeLines),
+      attributeName: functionSignatureParser.getAttributeName(
+        functionScopeLines!
+      ),
+      functionName: functionSignatureParser.getFunctionName(
+        functionScopeLines!
+      ),
       functionSignature: {
-        implicitArgs:
-          functionSignatureParser.getImplicitArgs(functionScopeLines),
-        explicitArgs:
-          functionSignatureParser.getExplicitArgs(functionScopeLines),
+        implicitArgs: functionSignatureParser.getImplicitArgs(
+          functionScopeLines!
+        ),
+        explicitArgs: functionSignatureParser.getExplicitArgs(
+          functionScopeLines!
+        ),
       },
       functionComment: {
         desc: functionCommentDescParser.parseCommentLines(commentLines!),
@@ -117,16 +122,5 @@ suite("integration-test:", () => {
     };
 
     assert.deepEqual(parsingTarget, parsingOutput, "failed to parse");
-
-    const raises = [
-      { name: "decimals", type: "", desc: "decimals exceed 2^8" },
-      {
-        name: "recipient",
-        type: "",
-        desc: "cannot mint to the zero address",
-      },
-      { name: "initial_supply", type: "", desc: "not valid Uint256" },
-      { name: "initial_supply", type: "", desc: "mint overflow" },
-    ];
   });
 });

--- a/src/test/suite/integration/constructor.test.ts
+++ b/src/test/suite/integration/constructor.test.ts
@@ -36,90 +36,96 @@ suite("integration-test:", () => {
     const functionCommentReturnsParser = new FunctionCommentReturnsParser();
     const functionCommentRaisesParser = new FunctionCommentRaisesParser();
 
-    const parsingTarget = [{
-      attributeName: "constructor",
-      functionName: "constructor",
-      functionSignature: {
-        implicitArgs: [
-          { name: "syscall_ptr", type: "felt*" },
-          { name: "pedersen_ptr", type: "HashBuiltin*" },
-          { name: "range_check_ptr", type: "" },
-        ],
-        explicitArgs: [
-          { name: "name", type: "felt" },
-          { name: "symbol", type: "felt" },
-          { name: "decimals", type: "Uint256" },
-          { name: "initial_supply", type: "Uint256" },
-          { name: "recipient", type: "felt" },
-        ],
+    const parsingTarget = [
+      {
+        attributeName: "constructor",
+        functionName: "constructor",
+        functionSignature: {
+          implicitArgs: [
+            { name: "syscall_ptr", type: "felt*" },
+            { name: "pedersen_ptr", type: "HashBuiltin*" },
+            { name: "range_check_ptr", type: "" },
+          ],
+          explicitArgs: [
+            { name: "name", type: "felt" },
+            { name: "symbol", type: "felt" },
+            { name: "decimals", type: "Uint256" },
+            { name: "initial_supply", type: "Uint256" },
+            { name: "recipient", type: "felt" },
+          ],
+        },
+        functionComment: {
+          desc: [{ name: "", type: "", desc: "Initialize the contract" }],
+          implicitArgs: [
+            { name: "syscall_ptr", type: "felt*", desc: "" },
+            { name: "pedersen_ptr", type: "HashBuiltin", desc: "" },
+            { name: "range_check_ptr", type: "", desc: "" },
+          ],
+          explicitArgs: [
+            { name: "name", type: "felt", desc: "name of the token" },
+            { name: "symbol", type: "felt", desc: "symbol of the token" },
+            {
+              name: "decimals",
+              type: "Uint256",
+              desc: "floating point of the token",
+            },
+            {
+              name: "initial_supply",
+              type: "Uint256",
+              desc: "amount of initial supply of the token",
+            },
+            {
+              name: "recipient",
+              type: "felt",
+              desc: "the address of recipient of the initial supply",
+            },
+          ],
+          returns: [{ name: "", type: "", desc: "None" }],
+          raises: [
+            { name: "decimals", type: "", desc: "decimals exceed 2^8" },
+            {
+              name: "recipient",
+              type: "",
+              desc: "cannot mint to the zero address",
+            },
+            { name: "initial_supply", type: "", desc: "not valid Uint256" },
+            { name: "initial_supply", type: "", desc: "mint overflow" },
+          ],
+        },
       },
-      functionComment: {
-        desc: [{ name: "", type: "", desc: "Initialize the contract" }],
-        implicitArgs: [
-          { name: "syscall_ptr", type: "felt*", desc: "" },
-          { name: "pedersen_ptr", type: "HashBuiltin", desc: "" },
-          { name: "range_check_ptr", type: "", desc: "" },
-        ],
-        explicitArgs: [
-          { name: "name", type: "felt", desc: "name of the token" },
-          { name: "symbol", type: "felt", desc: "symbol of the token" },
-          {
-            name: "decimals",
-            type: "Uint256",
-            desc: "floating point of the token",
-          },
-          {
-            name: "initial_supply",
-            type: "Uint256",
-            desc: "amount of initial supply of the token",
-          },
-          {
-            name: "recipient",
-            type: "felt",
-            desc: "the address of recipient of the initial supply",
-          },
-        ],
-        returns: [{ name: "", type: "", desc: "None" }],
-        raises: [
-          { name: "decimals", type: "", desc: "decimals exceed 2^8" },
-          {
-            name: "recipient",
-            type: "",
-            desc: "cannot mint to the zero address",
-          },
-          { name: "initial_supply", type: "", desc: "not valid Uint256" },
-          { name: "initial_supply", type: "", desc: "mint overflow" },
-        ],
-      },
-    }];
+    ];
 
-    var parsingOutput = [{
-      attributeName: functionSignatureParser.getAttributeName(
-        functionScopeLines![0]
-      ),
-      functionName: functionSignatureParser.getFunctionName(
-        functionScopeLines![0]
-      ),
-      functionSignature: {
-        implicitArgs: functionSignatureParser.getImplicitArgs(
+    var parsingOutput = [
+      {
+        attributeName: functionSignatureParser.getAttributeName(
           functionScopeLines![0]
         ),
-        explicitArgs: functionSignatureParser.getExplicitArgs(
+        functionName: functionSignatureParser.getFunctionName(
           functionScopeLines![0]
         ),
+        functionSignature: {
+          implicitArgs: functionSignatureParser.getImplicitArgs(
+            functionScopeLines![0]
+          ),
+          explicitArgs: functionSignatureParser.getExplicitArgs(
+            functionScopeLines![0]
+          ),
+        },
+        functionComment: {
+          desc: functionCommentDescParser.parseCommentLines(commentLines!),
+          implicitArgs: functionCommentImplicitArgsParser.parseCommentLines(
+            commentLines!
+          ),
+          explicitArgs: functionCommentExplicitArgsParser.parseCommentLines(
+            commentLines!
+          ),
+          returns: functionCommentReturnsParser.parseCommentLines(
+            commentLines!
+          ),
+          raises: functionCommentRaisesParser.parseCommentLines(commentLines!),
+        },
       },
-      functionComment: {
-        desc: functionCommentDescParser.parseCommentLines(commentLines!),
-        implicitArgs: functionCommentImplicitArgsParser.parseCommentLines(
-          commentLines!
-        ),
-        explicitArgs: functionCommentExplicitArgsParser.parseCommentLines(
-          commentLines!
-        ),
-        returns: functionCommentReturnsParser.parseCommentLines(commentLines!),
-        raises: functionCommentRaisesParser.parseCommentLines(commentLines!),
-      },
-    }];
+    ];
 
     assert.deepEqual(parsingTarget, parsingOutput, "failed to parse");
   });

--- a/src/test/suite/integration/main.test.ts
+++ b/src/test/suite/integration/main.test.ts
@@ -15,7 +15,7 @@ suite("integration-test:", () => {
       "constructor"
     );
 
-    const parsingTarget = {
+    const parsingTarget = [{
       attributeName: "constructor",
       functionName: "constructor",
       functionSignature: {
@@ -70,7 +70,7 @@ suite("integration-test:", () => {
           { name: "initial_supply", type: "", desc: "mint overflow" },
         ],
       },
-    };
+    }];
 
     assert.deepEqual(
       parsingTarget,

--- a/src/test/suite/integration/main.test.ts
+++ b/src/test/suite/integration/main.test.ts
@@ -15,62 +15,64 @@ suite("integration-test:", () => {
       "constructor"
     );
 
-    const parsingTarget = [{
-      attributeName: "constructor",
-      functionName: "constructor",
-      functionSignature: {
-        implicitArgs: [
-          { name: "syscall_ptr", type: "felt*" },
-          { name: "pedersen_ptr", type: "HashBuiltin*" },
-          { name: "range_check_ptr", type: "" },
-        ],
-        explicitArgs: [
-          { name: "name", type: "felt" },
-          { name: "symbol", type: "felt" },
-          { name: "decimals", type: "Uint256" },
-          { name: "initial_supply", type: "Uint256" },
-          { name: "recipient", type: "felt" },
-        ],
+    const parsingTarget = [
+      {
+        attributeName: "constructor",
+        functionName: "constructor",
+        functionSignature: {
+          implicitArgs: [
+            { name: "syscall_ptr", type: "felt*" },
+            { name: "pedersen_ptr", type: "HashBuiltin*" },
+            { name: "range_check_ptr", type: "" },
+          ],
+          explicitArgs: [
+            { name: "name", type: "felt" },
+            { name: "symbol", type: "felt" },
+            { name: "decimals", type: "Uint256" },
+            { name: "initial_supply", type: "Uint256" },
+            { name: "recipient", type: "felt" },
+          ],
+        },
+        functionComment: {
+          desc: [{ name: "", type: "", desc: "Initialize the contract" }],
+          implicitArgs: [
+            { name: "syscall_ptr", type: "felt*", desc: "" },
+            { name: "pedersen_ptr", type: "HashBuiltin", desc: "" },
+            { name: "range_check_ptr", type: "", desc: "" },
+          ],
+          explicitArgs: [
+            { name: "name", type: "felt", desc: "name of the token" },
+            { name: "symbol", type: "felt", desc: "symbol of the token" },
+            {
+              name: "decimals",
+              type: "Uint256",
+              desc: "floating point of the token",
+            },
+            {
+              name: "initial_supply",
+              type: "Uint256",
+              desc: "amount of initial supply of the token",
+            },
+            {
+              name: "recipient",
+              type: "felt",
+              desc: "the address of recipient of the initial supply",
+            },
+          ],
+          returns: [{ name: "", type: "", desc: "None" }],
+          raises: [
+            { name: "decimals", type: "", desc: "decimals exceed 2^8" },
+            {
+              name: "recipient",
+              type: "",
+              desc: "cannot mint to the zero address",
+            },
+            { name: "initial_supply", type: "", desc: "not valid Uint256" },
+            { name: "initial_supply", type: "", desc: "mint overflow" },
+          ],
+        },
       },
-      functionComment: {
-        desc: [{ name: "", type: "", desc: "Initialize the contract" }],
-        implicitArgs: [
-          { name: "syscall_ptr", type: "felt*", desc: "" },
-          { name: "pedersen_ptr", type: "HashBuiltin", desc: "" },
-          { name: "range_check_ptr", type: "", desc: "" },
-        ],
-        explicitArgs: [
-          { name: "name", type: "felt", desc: "name of the token" },
-          { name: "symbol", type: "felt", desc: "symbol of the token" },
-          {
-            name: "decimals",
-            type: "Uint256",
-            desc: "floating point of the token",
-          },
-          {
-            name: "initial_supply",
-            type: "Uint256",
-            desc: "amount of initial supply of the token",
-          },
-          {
-            name: "recipient",
-            type: "felt",
-            desc: "the address of recipient of the initial supply",
-          },
-        ],
-        returns: [{ name: "", type: "", desc: "None" }],
-        raises: [
-          { name: "decimals", type: "", desc: "decimals exceed 2^8" },
-          {
-            name: "recipient",
-            type: "",
-            desc: "cannot mint to the zero address",
-          },
-          { name: "initial_supply", type: "", desc: "not valid Uint256" },
-          { name: "initial_supply", type: "", desc: "mint overflow" },
-        ],
-      },
-    }];
+    ];
 
     assert.deepEqual(
       parsingTarget,


### PR DESCRIPTION
getScopeParsingResult so it will return list of `ParsingResult` since there might be multiple scope, for instance `view` ,but the current implementation only return one