### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 16
           cache: "yarn"
           registry-url: "https://registry.npmjs.org"
+          cache-dependency-path: "cli/yarn.lock"
       - name: installing yarn
         run: npm install -g yarn
       - run: yarn install --from-lockfile


### PR DESCRIPTION
The previously merged PR didn't specify the path to the lockfile in the `setup-node` part. This PR should fix it.